### PR TITLE
Prepare project for npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+tests/
+src/
+.vscode/
+.eslintrc.js
+.eslintignore
+.gitignore
+.prettierrc
+jest.config.js
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "scalaesque-ts",
   "version": "0.9.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
   "dependencies": {
     "@types/node": "^13.7.4",
     "benchmark": "^2.1.4"
@@ -23,7 +23,8 @@
     "start": "node build/_Main.js",
     "prestart": "rm -r build && npm run build",
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "prepublishOnly": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./Option";
+export * from "./Seq";
+export * from "./Try";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es6",
         "lib": ["es6"],
-        "outDir": "./build",
+        "outDir": "./dist",
         "rootDir": "./src",
         "sourceMap": true,
         "module": "CommonJS",


### PR DESCRIPTION
Ok, j'ai configuré tout ce qu'il fallait, normalement j'ai rien oublié
Dans le package.json j'ai rajouter une étape de prépublish pour refaire un build, et j'ai mis dans la clé main, la ou doit pointer les imports. J'ai créer un index.ts qui est juste la pour reexporter tout dans un seul fichier (c'est pas obliger, mais c'est mieux quand ça sera utilisé).
J'ai changé le nom du output pour avoir `dist` plutot que `build`. 
Et j'ai recréé un npmignore